### PR TITLE
add cargo.toml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ protoc_grpcio::compile_grpc_protos(
 ).expect("failed to compile gRPC definitions");
 ```
 
+## Example `Cargo.toml`
+
+```yaml
+[package]
+# ...
+build = "build.rs"
+
+[build-dependencies]
+protoc-grpcio = "0.1.0"
+```
+
 ## Credits
 
 Credit to both the TiKV project developers for


### PR DESCRIPTION
It took me a few minutes to figure out that I was missing `build-dependencies`.
Maybe this helps others.