### PR TITLE
updates grpcio-compiler to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protoc-grpcio"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Matt Pelland <matt@pelland.io>"]
 license = "Apache-2.0"
 keywords = ["compiler", "grpc", "protobuf", "grpc-rs"]
@@ -11,7 +11,7 @@ API for programatically invoking the grpcio (grpc-rs) gRPC compiler
 """
 
 [dependencies]
-grpcio-compiler = "0.3"
+grpcio-compiler = "0.4"
 failure = "0.1"
 mktemp = "0.3"
 protobuf = "2.0"

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -47,9 +47,9 @@ name = "example"
 version = "0.0.1"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "protoc-grpcio 0.2.0",
+ "protoc-grpcio 0.3.0",
 ]
 
 [[package]]
@@ -92,19 +92,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grpcio"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grpcio-compiler"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "protobuf 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "grpcio-sys"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -126,14 +126,6 @@ dependencies = [
 name = "libc"
 version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "log"
@@ -179,10 +171,10 @@ dependencies = [
 
 [[package]]
 name = "protoc-grpcio"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio-compiler 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio-compiler 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -296,11 +288,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
-"checksum grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6420fb7aca82b4bf1cf98aa2c70a55cb0cbaa4c5152ba51a47c37d758ac27b2d"
-"checksum grpcio-compiler 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a63ccc27b0099347d2bea2c3d0f1c79c018a13cfd08b814a1992e341b645d5e1"
-"checksum grpcio-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5d45a6906ba6faa1be0f04bb61c0a49aef5f279f090b0d24d81912c1c08b995e"
+"checksum grpcio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6ceb617aadae035882ff0e96fc312e4c7f65abc26aad9336f1e5d199d588a702"
+"checksum grpcio-compiler 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af2c2cd5ab52273ee9fc1406fe3a0bca7a9dd203f550905badc003c0a85c25a6"
+"checksum grpcio-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c01243bb555ae2ba819d428cffb7e93575ae047cf033f6242959a8a9ecc51ef6"
 "checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
-"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum mktemp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77001ceb9eed65439f3dc2a2543f9ba1417d912686bf224a7738d0966e6dcd69"
 "checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/client.rs"
 
 [dependencies]
 futures = "0.1.16"
-grpcio = "0.3.0"
+grpcio = "0.4.0"
 protobuf = "2.0.2"
 
 [build-dependencies]

--- a/example/src/server.rs
+++ b/example/src/server.rs
@@ -17,17 +17,18 @@ use protos::diner_grpc::{self, Diner};
 struct DinerService;
 
 impl Diner for DinerService {
-    fn eat(&self, ctx: RpcContext, order: Order, sink: UnarySink<Check>) {
+    fn eat(&mut self, ctx: RpcContext, order: Order, sink: UnarySink<Check>) {
         println!("Received Order {{ {:?} }}", order);
         let mut check = Check::new();
         check.set_total(order.get_items().iter().fold(0.0, |total, &item| {
             total + match item {
                 Item::SPAM => 0.05,
                 Item::EGGS => 0.25,
-                Item::HAM => 1.0
+                Item::HAM => 1.0,
             }
         }));
-        let f = sink.success(check.clone())
+        let f = sink
+            .success(check.clone())
             .map(move |_| println!("Responded with Check {{ {:?} }}", check))
             .map_err(move |err| eprintln!("Failed to reply: {:?}", err));
         ctx.spawn(f)


### PR DESCRIPTION
The new version of `grpcio-compiler` changes the codegen output (most saliently, `&self` is changed to `&mut self` in the rpc handlers).  This pull request updates to the latest version of `grpcio-compiler` and updates example code to use the new output. 

As the change in codegen output will break existing code, this pull request also bumps `protoc-grpcio` version number.

Thanks!