### PR TITLE
Fix clippy warning

### DIFF
--- a/example/src/client.rs
+++ b/example/src/client.rs
@@ -16,7 +16,7 @@ fn main() {
     }
     let port = args[1]
         .parse::<u16>()
-        .expect(format!("{} is not a valid port number", args[1]).as_str());
+        .unwrap_or_else(|_| panic!("{} is not a valid port number", args[1]));
 
     let env = Arc::new(EnvBuilder::new().build());
     let ch = ChannelBuilder::new(env).connect(format!("localhost:{}", port).as_str());


### PR DESCRIPTION
Clippy complains about usage of `expect` followed by a function call. Fixed with clippy's suggestion, `unwrap_or_else`.
https://rust-lang.github.io/rust-clippy/master/index.html#expect_fun_call