### PR TITLE
Fix protoc-grpcio version after example update

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ grpcio = "0.2.0"
 protobuf = "1.4.1"
 
 [build-dependencies]
-protoc-grpcio = "0.3.1"
+protoc-grpcio = "1.0.2"
 ```
 
 You can inspect this example under [`example/`](example) by compiling and running the example


### PR DESCRIPTION
Was actually https://github.com/mtp401/protoc-grpcio/pull/23 but git abused me (and vice versa)