### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ maintenance = { status = "actively-developed" }
 travis-ci = { repository = "mtp401/protoc-grpcio" }
 
 [dependencies]
-grpcio-compiler = "0.5.0-alpha.2"
+grpcio-compiler = "0.5"
 failure = "0.1"
 tempfile = "3.1"
-protobuf = "2.8"
-protobuf-codegen = "2.8"
-protoc = "2.8"
+protobuf = "2.13"
+protobuf-codegen = "2.13"
+protoc = "2.13"


### PR DESCRIPTION
After an update to the protobuf library, my builds started complaining about `::protobuf::lazy::ONCE_INIT` and `::protobuf::reflect::MessageDescriptor::new` being deprecated. This PR updates to the newest protobuf minor version to remove usage of those deprecated APIs.

This PR also bumps the grpio-compiler dep off of the alpha on to the released minor version.